### PR TITLE
Fix for the priority of operators

### DIFF
--- a/plugin/vimtweak.vim
+++ b/plugin/vimtweak.vim
@@ -2,7 +2,7 @@ if !has('gui_running') || (!has('win32') && !has('win64'))
   finish
 endif
 
-let g:vimtweak_dll_path = expand('<sfile>:p:h:h') . has('win64') ? '/vimtweak64.dll' : '/vimtweak32.dll'
+let g:vimtweak_dll_path = expand('<sfile>:p:h:h') . (has('win64') ? '/vimtweak64.dll' : '/vimtweak32.dll')
 
 
 


### PR DESCRIPTION
According to `help expression-syntax`, the priority of the operator `.` (string concatenation) is higher than `if-then-else` (ternary operator).
So `g:vimtweak_dll_path` doesn't seem to be set right.

This PR fix the priority of operators.